### PR TITLE
fix progress bar no full fill bar

### DIFF
--- a/bar.go
+++ b/bar.go
@@ -120,7 +120,7 @@ func (bar *Bar) play(cur int64) (n int, err error) {
 	bar.percent = bar.getPercent()
 	
 	if cur == bar.max {
-		remain := 50 - len(bar.rate) / 3
+		remain := (150 - len(bar.rate)) / 3
 		for i := 0; i < remain; i++ {
 			bar.rate += bar.options.Graph
 		}

--- a/bar.go
+++ b/bar.go
@@ -118,8 +118,13 @@ func (bar *Bar) play(cur int64) (n int, err error) {
 	last := bar.percent
 	bar.step = cur
 	bar.percent = bar.getPercent()
-
-	if bar.percent > last {
+	
+	if cur == bar.max {
+		remain := (150 - len(bar.rate)) / 3
+		for i := 0; i < remain; i++ {
+			bar.rate += bar.options.Graph
+		}
+	} else if bar.percent > last {
 		if change := (bar.percent - last) / 2; change != 0 {
 			for i := int64(0); i < (bar.percent-last)/2; i++ {
 				bar.rate += bar.options.Graph

--- a/bar.go
+++ b/bar.go
@@ -120,7 +120,7 @@ func (bar *Bar) play(cur int64) (n int, err error) {
 	bar.percent = bar.getPercent()
 	
 	if cur == bar.max {
-		remain := (150 - len(bar.rate)) / 3
+		remain := 50 - len(bar.rate) / 3
 		for i := 0; i < remain; i++ {
 			bar.rate += bar.options.Graph
 		}


### PR DESCRIPTION
when bar.max = 14, tail bar not full fill.

```
bar := progress.New(0, 14)

	_, _ = bar.Start()
	defer func() {
		if _, err := bar.Stop(); err != nil {
			log.Printf("failed to finish progress: %v", err)
		}
	}()

	for i := 0; i < 14; i++ {
		_, _ = bar.Advance(1)
	}
```

![64E22255-6049-4DC6-94BF-5AA4D7BF11A4](https://user-images.githubusercontent.com/1835487/187017925-fde39aa8-6cd9-44c5-b8e2-f858a4733bfa.png)

